### PR TITLE
게시글 페이지에 접근할 때, 노출되는 에러 수정

### DIFF
--- a/gitmon-next/src/app/blog/[id]/page.tsx
+++ b/gitmon-next/src/app/blog/[id]/page.tsx
@@ -1,29 +1,13 @@
-"use client";
-
 import IntroComponent from "@components/Intro";
-import Loading from "@components/Loading";
 import PostList from "@components/Post/PostList";
-import { fetchPosts } from "@hooks/temp/useDummyData";
-import { useQuery } from "@tanstack/react-query";
-import { useParams } from "next/navigation";
 
 function BlogMain() {
-  const { id } = useParams<{
-    id: string;
-  }>();
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["posts", id],
-    queryFn: fetchPosts,
-  });
-
-  if (isLoading) return <Loading />;
-  if (error) return <div>Error loading posts</div>;
 
   return (
     <>
       <IntroComponent />
       <div className="grid grid-cols-1 gap-8">
-        <PostList posts={data ?? []} id={id} />
+        <PostList />
       </div>
     </>
   );

--- a/gitmon-next/src/components/Navbar.tsx
+++ b/gitmon-next/src/components/Navbar.tsx
@@ -25,11 +25,11 @@ const MenuItem: React.FC<MenuItemProps> = ({ href, label }) => {
 
 const Navbar = () => {
   const navList = [
-    { href: '/', label: 'Home' },
-    { href: '/', label: 'About' },
+    { href: '/home', label: 'Home' },
+    // { href: '/about', label: 'About' },
     { href: 'blog', label: 'Blog' },
-    { href: '/', label: 'Projects' },
-    { href: '/', label: 'Archive' },
+    // { href: '/projects', label: 'Projects' },
+    // { href: '/archive', label: 'Archive' },
   ];
   return (
     <nav>

--- a/gitmon-next/src/components/Post/PostList.tsx
+++ b/gitmon-next/src/components/Post/PostList.tsx
@@ -1,21 +1,34 @@
+'use client'
+
 import React from "react";
 
 import MarkdownRenderer from "@components/MarkdownRenderer";
 import { Button } from "@components/ui/button";
 
 import type { Post } from "./types";
-import { redirect, usePathname } from "next/navigation";
+import { redirect, useParams, usePathname } from "next/navigation";
 import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { fetchPosts } from "@hooks/temp/useDummyData";
+import Loading from "@components/Loading";
 
-interface PostListProps {
-  posts: Post[];
-  id: string;
-}
+const PostList: React.FC = () => {
+  const { id } = useParams<{
+    id: string;
+  }>();
 
-const PostList: React.FC<PostListProps> = ({ posts, id }) => {
+  const { data = [], isLoading, error } = useQuery({
+    queryKey: ["posts", id],
+    queryFn: fetchPosts,
+  });
+
   const handleAddPostClick = () => {
     redirect(`/blog/${id}/posts/add`);
   };
+
+  if (isLoading) return <Loading />;
+  if (error) return <div>Error loading posts</div>;
+
   return (
     <div>
       <div className="flex justify-between items-center">
@@ -23,7 +36,7 @@ const PostList: React.FC<PostListProps> = ({ posts, id }) => {
         {/* 해당 기능은 아마 auth에 의해 노출이 조작되어야 것임 */}
         <Button onClick={handleAddPostClick}>Add Post</Button>
       </div>
-      {posts.map((post, index) => (
+      {data.map((post, index) => (
         <PostListItem key={index} post={post} />
       ))}
     </div>


### PR DESCRIPTION
- same key
  - 아직 구현되지 않은 페이지의 routing을 '/'으로 설정해두어 navbar에 same key와 관련된 에러가 있어서 수정했습니다. 
- 'useParams' + 클라이언트 컴포넌트에서 비동기 함수 사용
  - PostList의 IntroPage에서 사용하는 비동기 함수와 부모에서 사용하는 useParams가 충돌을 일으키는 이슈가 있었습니다.
  - 부모의 useParams를 자식(Post)으로 한단계 옮겨 충돌을 회피했습니다. 좋은 방법인지는 잘 모르겠습니다