### PR TITLE
도커 이미지 최적화

### DIFF
--- a/gitmon-client/Dockerfile
+++ b/gitmon-client/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM node:lts AS runtime
+FROM node:lts-alpine AS runtime
 
 WORKDIR /app
 


### PR DESCRIPTION
- 배포되는 컨테이너 이미지를 alpine 으로 변경
- 변경 결과: 도커 이미지 사이즈가 줄었음 (1.71GB -> 745MB)