### PR TITLE
Feature/upload image

### DIFF
--- a/gitmon-client/src/app/[id]/[repo]/[slug]/update/UpdatePost.tsx
+++ b/gitmon-client/src/app/[id]/[repo]/[slug]/update/UpdatePost.tsx
@@ -99,7 +99,7 @@ export default function UpdatePost({ token, post }: UpdatePostProps) {
 
   return (
     <div className="p-4">
-      <PostForm onPostSaved={handleSavePost} post={post} />
+      <PostForm onPostSaved={handleSavePost} post={post} token={token} />
     </div>
   )
 }

--- a/gitmon-client/src/app/create-post/AddPost.tsx
+++ b/gitmon-client/src/app/create-post/AddPost.tsx
@@ -91,7 +91,7 @@ export default function AddPost({ token }: { token: string | null }) {
 
   return (
     <div className="p-4">
-      <PostForm onPostSaved={handleSavePost} post={null} />
+      <PostForm onPostSaved={handleSavePost} post={null} token={token} />
     </div>
   )
 }

--- a/gitmon-client/src/components/Post/PostForm.tsx
+++ b/gitmon-client/src/components/Post/PostForm.tsx
@@ -131,8 +131,8 @@ export function PostForm({ onPostSaved, post, token }: PostFormProps) {
       setIsUploading(true)
       const url = await uploadImage(imageFile, token)
       insertTextAtCursor(`![](${url})`)
-    } catch (e: any) {
-      toast(e?.message || '이미지 업로드에 실패했습니다.')
+    } catch (e: unknown) {
+      toast((e as Error)?.message || '이미지 업로드에 실패했습니다.')
     } finally {
       setIsUploading(false)
     }

--- a/gitmon-client/src/components/Post/PostForm.tsx
+++ b/gitmon-client/src/components/Post/PostForm.tsx
@@ -238,7 +238,9 @@ export function PostForm({ onPostSaved, post, token }: PostFormProps) {
         <TabsContent value="write" className="mt-2">
           <Textarea
             ref={textareaRef}
-            placeholder={isUploading ? "이미지 업로드 중..." : "Write your post content in markdown..."}
+            placeholder={
+              isUploading ? '이미지 업로드 중...' : 'Write your post content in markdown...'
+            }
             value={content}
             onChange={e => setContent(e.target.value)}
             onDragOver={onDragOver}
@@ -264,7 +266,11 @@ export function PostForm({ onPostSaved, post, token }: PostFormProps) {
             </Link>
           </Button>
 
-          <Button onClick={() => onPostSaved({ title, content })} disabled={isUploading} className="gap-2">
+          <Button
+            onClick={() => onPostSaved({ title, content })}
+            disabled={isUploading}
+            className="gap-2"
+          >
             <Save size={16} />
             <p>{isUploading ? '업로드 중...' : '글 작성'}</p>
           </Button>

--- a/gitmon-client/src/components/Post/PostForm.tsx
+++ b/gitmon-client/src/components/Post/PostForm.tsx
@@ -238,12 +238,13 @@ export function PostForm({ onPostSaved, post, token }: PostFormProps) {
         <TabsContent value="write" className="mt-2">
           <Textarea
             ref={textareaRef}
-            placeholder="Write your post content in markdown..."
+            placeholder={isUploading ? "이미지 업로드 중..." : "Write your post content in markdown..."}
             value={content}
             onChange={e => setContent(e.target.value)}
             onDragOver={onDragOver}
             onDrop={onDrop}
             onPaste={onPaste}
+            disabled={isUploading}
             className="min-h-[400px] font-mono text-sm resize-y"
           />
         </TabsContent>
@@ -263,9 +264,9 @@ export function PostForm({ onPostSaved, post, token }: PostFormProps) {
             </Link>
           </Button>
 
-          <Button onClick={() => onPostSaved({ title, content })} className="gap-2">
+          <Button onClick={() => onPostSaved({ title, content })} disabled={isUploading} className="gap-2">
             <Save size={16} />
-            <p>글 작성</p>
+            <p>{isUploading ? '업로드 중...' : '글 작성'}</p>
           </Button>
         </div>
       </div>

--- a/gitmon-client/src/components/Post/PostForm.tsx
+++ b/gitmon-client/src/components/Post/PostForm.tsx
@@ -46,7 +46,11 @@ export function PostForm({ onPostSaved, post, token }: PostFormProps) {
 
   const insertTextAtCursor = useCallback(
     (textBefore: string, textAfter = '') => {
-      if (!textareaRef.current) return
+      if (!textareaRef.current) {
+        // Textarea가 언마운트된 경우(예: Preview 탭): 본문 끝에 추가
+        setContent(prev => prev + textBefore + textAfter)
+        return
+      }
 
       const textarea = textareaRef.current
       const start = textarea.selectionStart

--- a/gitmon-client/src/components/Post/PostForm.tsx
+++ b/gitmon-client/src/components/Post/PostForm.tsx
@@ -9,6 +9,8 @@ import { Card } from '@components/ui/card'
 import MarkdownPreview from './markdown-preview'
 import ToolbarButton from './toolbar-button'
 import ImageUploader from './image-uploader'
+import { uploadImage } from '@lib/upload'
+import { toast } from 'sonner'
 import {
   Bold,
   Italic,
@@ -31,13 +33,15 @@ import { Post } from '@lib/types'
 interface PostFormProps {
   onPostSaved: (post: { title: string; content: string }) => void
   post: Omit<Post, 'id'> | null
+  token?: string | null
 }
 
-export function PostForm({ onPostSaved, post }: PostFormProps) {
+export function PostForm({ onPostSaved, post, token }: PostFormProps) {
   const params = useParams()
   const [title, setTitle] = useState(post?.title || '')
   const [content, setContent] = useState(post?.content || '')
   const [showImageUploader, setShowImageUploader] = useState(false)
+  const [isUploading, setIsUploading] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const insertTextAtCursor = useCallback(
@@ -106,8 +110,51 @@ export function PostForm({ onPostSaved, post }: PostFormProps) {
   }
 
   const handleImageInsert = (imageUrl: string) => {
-    insertTextAtCursor(`![Image](${imageUrl})`)
+    insertTextAtCursor(`![](${imageUrl})`)
     setShowImageUploader(false)
+  }
+
+  const handleFilesToUpload = async (files: FileList | File[]) => {
+    if (!files || files.length === 0) return
+    const fileArray = Array.from(files)
+    const imageFile = fileArray.find(f => f.type.startsWith('image/'))
+    if (!imageFile) return
+    if (!token) {
+      toast('로그인이 필요하거나 토큰이 없습니다.')
+      return
+    }
+    try {
+      setIsUploading(true)
+      const url = await uploadImage(imageFile, token)
+      insertTextAtCursor(`![](${url})`)
+    } catch (e: any) {
+      toast(e?.message || '이미지 업로드에 실패했습니다.')
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
+  const onDragOver = (e: React.DragEvent<HTMLTextAreaElement>) => {
+    e.preventDefault()
+  }
+
+  const onDrop = async (e: React.DragEvent<HTMLTextAreaElement>) => {
+    e.preventDefault()
+    const dt = e.dataTransfer
+    if (dt?.files && dt.files.length > 0) {
+      await handleFilesToUpload(dt.files)
+    }
+  }
+
+  const onPaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = e.clipboardData?.files
+    if (items && items.length > 0) {
+      const hasImage = Array.from(items).some(f => f.type.startsWith('image/'))
+      if (hasImage) {
+        e.preventDefault()
+        await handleFilesToUpload(items)
+      }
+    }
   }
 
   return (
@@ -190,6 +237,9 @@ export function PostForm({ onPostSaved, post }: PostFormProps) {
             placeholder="Write your post content in markdown..."
             value={content}
             onChange={e => setContent(e.target.value)}
+            onDragOver={onDragOver}
+            onDrop={onDrop}
+            onPaste={onPaste}
             className="min-h-[400px] font-mono text-sm resize-y"
           />
         </TabsContent>
@@ -218,6 +268,7 @@ export function PostForm({ onPostSaved, post }: PostFormProps) {
 
       {showImageUploader && (
         <ImageUploader
+          token={token || null}
           onImageInsert={handleImageInsert}
           onCancel={() => setShowImageUploader(false)}
         />

--- a/gitmon-client/src/components/Post/image-uploader.tsx
+++ b/gitmon-client/src/components/Post/image-uploader.tsx
@@ -119,6 +119,7 @@ export default function ImageUploader({ onImageInsert, onCancel, token }: ImageU
                     alt="Preview"
                     width={200}
                     height={200}
+                    unoptimized
                     className="max-h-[200px] max-w-full object-contain border rounded"
                   />
                 </div>
@@ -142,6 +143,7 @@ export default function ImageUploader({ onImageInsert, onCancel, token }: ImageU
                     alt="Preview"
                     width={200}
                     height={200}
+                    unoptimized
                     className="max-h-[200px] max-w-full object-contain border rounded"
                     onError={() => {
                       toast('Failed to load image from URL')

--- a/gitmon-client/src/components/Post/image-uploader.tsx
+++ b/gitmon-client/src/components/Post/image-uploader.tsx
@@ -84,7 +84,10 @@ export default function ImageUploader({ onImageInsert, onCancel, token }: ImageU
           <div className="flex gap-4">
             <Button
               variant={uploadType === 'file' ? 'default' : 'outline'}
-              onClick={() => setUploadType('file')}
+              onClick={() => {
+                setUploadType('file')
+                setImageUrl('')
+              }}
               className="flex-1 gap-2"
             >
               <Upload size={16} />
@@ -92,7 +95,11 @@ export default function ImageUploader({ onImageInsert, onCancel, token }: ImageU
             </Button>
             <Button
               variant={uploadType === 'url' ? 'default' : 'outline'}
-              onClick={() => setUploadType('url')}
+              onClick={() => {
+                setUploadType('url')
+                setFile(null)
+                setPreviewUrl(null)
+              }}
               className="flex-1 gap-2"
             >
               <LinkIcon size={16} />
@@ -101,7 +108,7 @@ export default function ImageUploader({ onImageInsert, onCancel, token }: ImageU
           </div>
 
           {uploadType === 'file' ? (
-            <div className="grid gap-2">
+            <div className="grid gap-2" key="file">
               <Label htmlFor="image-upload">Select Image</Label>
               <Input id="image-upload" type="file" accept="image/*" onChange={handleFileChange} />
               {previewUrl && (
@@ -118,7 +125,7 @@ export default function ImageUploader({ onImageInsert, onCancel, token }: ImageU
               )}
             </div>
           ) : (
-            <div className="grid gap-2">
+            <div className="grid gap-2" key="url">
               <Label htmlFor="image-url">Image URL</Label>
               <Input
                 id="image-url"

--- a/gitmon-client/src/components/Post/image-uploader.tsx
+++ b/gitmon-client/src/components/Post/image-uploader.tsx
@@ -65,8 +65,8 @@ export default function ImageUploader({ onImageInsert, onCancel, token }: ImageU
         setIsUploading(true)
         const url = await uploadImage(file, token)
         onImageInsert(url)
-      } catch (e: any) {
-        toast(e?.message || '이미지 업로드에 실패했습니다.')
+      } catch (e: unknown) {
+        toast((e as Error)?.message || '이미지 업로드에 실패했습니다.')
       } finally {
         setIsUploading(false)
       }

--- a/gitmon-client/src/components/Post/image-uploader.tsx
+++ b/gitmon-client/src/components/Post/image-uploader.tsx
@@ -16,17 +16,20 @@ import {
 import { toast } from 'sonner'
 import { Upload, LinkIcon } from 'lucide-react'
 import Image from 'next/image'
+import { uploadImage } from '@lib/upload'
 
 interface ImageUploaderProps {
   onImageInsert: (imageUrl: string) => void
   onCancel: () => void
+  token: string | null
 }
 
-export default function ImageUploader({ onImageInsert, onCancel }: ImageUploaderProps) {
+export default function ImageUploader({ onImageInsert, onCancel, token }: ImageUploaderProps) {
   const [uploadType, setUploadType] = useState<'file' | 'url'>('file')
   const [imageUrl, setImageUrl] = useState('')
   const [file, setFile] = useState<File | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [isUploading, setIsUploading] = useState(false)
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
@@ -42,7 +45,7 @@ export default function ImageUploader({ onImageInsert, onCancel }: ImageUploader
     }
   }
 
-  const handleInsert = () => {
+  const handleInsert = async () => {
     if (uploadType === 'url') {
       if (!imageUrl.trim()) {
         toast('Please enter an image URL')
@@ -54,11 +57,18 @@ export default function ImageUploader({ onImageInsert, onCancel }: ImageUploader
         toast('Please select an image file')
         return
       }
-
-      // In a real application, you would upload the file to a server
-      // and get back a URL. For this demo, we'll use the preview URL.
-      if (previewUrl) {
-        onImageInsert(previewUrl)
+      if (!token) {
+        toast('로그인이 필요하거나 토큰이 없습니다.')
+        return
+      }
+      try {
+        setIsUploading(true)
+        const url = await uploadImage(file, token)
+        onImageInsert(url)
+      } catch (e: any) {
+        toast(e?.message || '이미지 업로드에 실패했습니다.')
+      } finally {
+        setIsUploading(false)
       }
     }
   }
@@ -100,6 +110,8 @@ export default function ImageUploader({ onImageInsert, onCancel }: ImageUploader
                   <Image
                     src={previewUrl || '/placeholder.svg'}
                     alt="Preview"
+                    width={200}
+                    height={200}
                     className="max-h-[200px] max-w-full object-contain border rounded"
                   />
                 </div>
@@ -121,6 +133,8 @@ export default function ImageUploader({ onImageInsert, onCancel }: ImageUploader
                   <Image
                     src={imageUrl || '/placeholder.svg'}
                     alt="Preview"
+                    width={200}
+                    height={200}
                     className="max-h-[200px] max-w-full object-contain border rounded"
                     onError={() => {
                       toast('Failed to load image from URL')
@@ -133,10 +147,12 @@ export default function ImageUploader({ onImageInsert, onCancel }: ImageUploader
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={onCancel}>
+          <Button variant="outline" onClick={onCancel} disabled={isUploading}>
             Cancel
           </Button>
-          <Button onClick={handleInsert}>Insert Image</Button>
+          <Button onClick={handleInsert} disabled={isUploading}>
+            {isUploading ? 'Uploading...' : 'Insert Image'}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/gitmon-client/src/lib/upload.ts
+++ b/gitmon-client/src/lib/upload.ts
@@ -3,6 +3,11 @@
 const MAX_BYTES = 10 * 1024 * 1024 // 10MB
 const ALLOWED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp', 'gif']
 
+interface UploadResponse {
+  data?: string
+  errorMessage?: string
+}
+
 function getExtension(filename: string): string {
   const parts = filename.split('.')
   return parts.length > 1 ? parts.pop()!.toLowerCase() : ''
@@ -43,7 +48,7 @@ export async function uploadImage(file: File, token: string): Promise<string> {
     body: form,
   })
 
-  let payload: any = await res.json()
+  const payload = (await res.json()) as UploadResponse
 
   if (res.status === 201) {
     const imageUrl = payload?.data
@@ -53,7 +58,7 @@ export async function uploadImage(file: File, token: string): Promise<string> {
     throw new Error('이미지 업로드 응답이 올바르지 않습니다.')
   }
 
-  const serverMessage = payload?.errorMessage as string | undefined
+  const serverMessage = payload?.errorMessage
 
   if (res.status === 400) {
     throw new Error(serverMessage || '허용되지 않은 이미지 확장자입니다.')
@@ -72,5 +77,3 @@ export const ImageUploadPolicy = {
   maxBytes: MAX_BYTES,
   allowedExtensions: ALLOWED_EXTENSIONS,
 }
-
-

--- a/gitmon-client/src/lib/upload.ts
+++ b/gitmon-client/src/lib/upload.ts
@@ -1,0 +1,76 @@
+// 이미지 업로드 유틸리티: 멀티파트 업로드 후 이미지 URL을 반환합니다.
+
+const MAX_BYTES = 10 * 1024 * 1024 // 10MB
+const ALLOWED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp', 'gif']
+
+function getExtension(filename: string): string {
+  const parts = filename.split('.')
+  return parts.length > 1 ? parts.pop()!.toLowerCase() : ''
+}
+
+function assertPreconditions(file: File) {
+  const ext = getExtension(file.name)
+  if (!file.type.startsWith('image/')) {
+    throw new Error('이미지 파일만 업로드할 수 있습니다.')
+  }
+  if (!ALLOWED_EXTENSIONS.includes(ext)) {
+    throw new Error('허용되지 않은 이미지 확장자입니다.')
+  }
+  if (file.size > MAX_BYTES) {
+    throw new Error('이미지 용량이 너무 큽니다. 최대 10MB까지 허용됩니다.')
+  }
+}
+
+export async function uploadImage(file: File, token: string): Promise<string> {
+  assertPreconditions(file)
+
+  const baseUrl = process.env.NEXT_PUBLIC_API_DOMAIN
+  if (!baseUrl) {
+    throw new Error('이미지 업로드 설정이 올바르지 않습니다(NEXT_PUBLIC_API_DOMAIN).')
+  }
+
+  const path = '/api/v1/posting/images'
+  const url = `${baseUrl}${path}`
+
+  const form = new FormData()
+  form.append('image', file)
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: form,
+  })
+
+  let payload: any = await res.json()
+
+  if (res.status === 201) {
+    const imageUrl = payload?.data
+    if (typeof imageUrl === 'string' && imageUrl.length > 0) {
+      return imageUrl
+    }
+    throw new Error('이미지 업로드 응답이 올바르지 않습니다.')
+  }
+
+  const serverMessage = payload?.errorMessage as string | undefined
+
+  if (res.status === 400) {
+    throw new Error(serverMessage || '허용되지 않은 이미지 확장자입니다.')
+  }
+  if (res.status === 409) {
+    throw new Error(serverMessage || '레포지토리가 아직 설정되지 않았습니다.')
+  }
+  if (res.status === 401 || res.status === 403) {
+    throw new Error(serverMessage || '인증이 만료되었거나 권한이 없습니다.')
+  }
+
+  throw new Error(serverMessage || '이미지 업로드에 실패했습니다.')
+}
+
+export const ImageUploadPolicy = {
+  maxBytes: MAX_BYTES,
+  allowedExtensions: ALLOWED_EXTENSIONS,
+}
+
+


### PR DESCRIPTION
### 의견
1. 이미지 업로드 기능 전반(파일 찾기, 드래그앤드랍, 클립보드 붙여넣기)을 게시글 작성/수정 양쪽에서 사용할 수 있도록 구현했습니다.
2. API 요청 함수를 따로 빼놓았는데, 일관성에 맞는 구현인지는 모르겠습니다..

### 문제 
1. 현재 “게시글 수정이 안 되는” 현상이 있는 것 같습니다.
2. 이미지 업로더에서 이미지 URL 입력 시 가끔 throw가 발생합니다(재현 X)